### PR TITLE
Add build definition, documentation and travis-CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+binaryheap
+nimcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+os:
+    - linux
+language: c
+install:
+    - git clone -b devel --depth 1 git://github.com/Araq/Nim.git
+    - (cd Nim && sh bootstrap.sh)
+    - export PATH=`pwd`/Nim/bin:$PATH
+script: make

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+#
+# Build instructions
+#
+
+# Make sure that any failure in a pipe fails the build
+SHELL = /bin/bash -o pipefail
+
+# Compile and test
+.PHONY: all
+all:
+	nim c -r binaryheap.nim
+
+# Watches for changes and reruns
+.PHONY: watch
+watch:
+	$(eval MAKEFLAGS += " -s ")
+	@while true; do \
+		make; \
+		echo "Done. Watching for changes"; \
+		inotifywait -qre close_write `find . -name "*.nim"` > /dev/null; \
+		echo "Change detected, re-running..."; \
+	done
+
+# Remove all build artifacts
+.PHONY: clean
+clean:
+	rm -f binaryheap
+	rm -rf nimcache
+

--- a/readme.md
+++ b/readme.md
@@ -5,3 +5,35 @@ This is a simple binary heap implementation, using a dynamic array (`seq`) as
 backend. Apart from the standard functionality peek/push/pop it also provides
 optimized versions for performing push+pop or pop+push, which can be handy for
 fixed-sized priority queues. The code should be self-explanatory.
+
+A Partial Tour
+--------------
+
+Below is an example of how to use this module. It contains a few of the
+procs available, but not all. Check out the source for the full set of
+functionality.
+
+```nimrod
+import binaryheap
+
+# Create a heap of ints
+var heap = newHeap[int]() do (a, b: int) -> int:
+    return a - b
+
+# Push a bunch of values
+heap.push(30)
+heap.push(4)
+heap.push(15)
+heap.push(1)
+
+# Prints "1" because our comparison function keeps the smallest value on top.
+# This also removes the value from the heap
+echo heap.pop
+
+# Prints "4" and leaves the value on the heap
+echo heap.peek
+
+# Print all values in the heap in unsorted order
+for item in heap:
+    echo item
+```

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,7 @@
-This is a simple binary heap implementation, using a dynamic array (`seq`) as backend. Apart from the standard functionality peek/push/pop it also provides optimized versions for performing push+pop or pop+push, which can be handy for fixed-sized priority queues. The code should be self-explanatory.
+Nim-Heap [![Build Status](https://travis-ci.org/bluenote10/nim-heap.svg?branch=master)](https://travis-ci.org/bluenote10/nim-heap)
+========
+
+This is a simple binary heap implementation, using a dynamic array (`seq`) as
+backend. Apart from the standard functionality peek/push/pop it also provides
+optimized versions for performing push+pop or pop+push, which can be handy for
+fixed-sized priority queues. The code should be self-explanatory.


### PR DESCRIPTION
I added a few logistical features:
- A make file with 3 targets: `all`, `watch` and `clean`
- Example code in the readme
- Travis-ci integration. Here is an example build: https://travis-ci.org/Nycto/nim-heap/builds/65708276
