### PR TITLE
Fix 'variable is defined but not used' warnings

### DIFF
--- a/binaryheap.nim
+++ b/binaryheap.nim
@@ -261,7 +261,7 @@ when isMainModule:
             h.push(random(100))
             h.assertHeapProperty
           for i in 1..N:
-            let x = h.pop
+            discard h.pop
             h.assertHeapProperty
           h.assertHeapProperty
 


### PR DESCRIPTION
The primary goal is to remove warnings that checkHeapProperty is defined but never used. This change accomplishes that by making sure it is always called, but becomes a no-op when debugging is disabled.
