### PR TITLE
Fix GcUnsafe2

### DIFF
--- a/binaryheap.nim
+++ b/binaryheap.nim
@@ -13,7 +13,7 @@ type
   Heap*[T] = object
     data: seq[T]
     size: int
-    comp: proc (x: T, y: T): int # CompareProc[T], why int not byte?
+    comp: proc (x: T, y: T): int {.gcsafe.} # CompareProc[T], why int not byte?
 
   EmptyHeapError* = object of Exception
 


### PR DESCRIPTION
There are tons of GcUnsafe2 warnings now, using nim-HEAD:

```
nim-heap/binaryheap.nim(45, 4) Warning: 'propFulfilled' is not GC-safe as it performs an indirect call here [GcUnsafe2]
 h.comp(h.data[indParent], h.data[indChild]) <= 0
  ^
nim-heap/binaryheap.nim(86, 6) Warning: 'siftdown' is not GC-safe as it calls 'propFulfilled' [GcUnsafe2]
...
```